### PR TITLE
Asymmetric movement

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -458,9 +458,9 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 // default settings
 
 #define DEFAULT_AXIS_STEPS_PER_UNIT   {88,88,2268,138}  // default steps per unit for Ultimaker {SD Patch}
-#define AXIS_STEPS_NEGATIVE           {78.7402,100.7402,200.0*8/3,760*1.1} // Step values to be used when travelling in the negative direction. Useful for threadless ball screws. Comment out if not needed
-#define DEFAULT_MAX_FEEDRATE          {500, 500, 5, 25}    // (mm/sec)
-#define DEFAULT_MAX_ACCELERATION      {9000,9000,100,10000}    // X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot.
+//#define AXIS_STEPS_NEGATIVE           {88,88,2268,138} // Step values to be used when travelling in the negative direction. Useful for threadless ball screws. Comment out if not needed
+#define DEFAULT_MAX_FEEDRATE          {500, 500, 5, 45}    // (mm/sec) {SD Patch}
+#define DEFAULT_MAX_ACCELERATION      {1200,1200,100,10000}    // X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot. {SD Patch}
 
 #define DEFAULT_ACCELERATION          1000    // X, Y, Z and E max acceleration in mm/s^2 for printing moves {SD Patch}
 #define DEFAULT_RETRACT_ACCELERATION  1000   // X, Y, Z and E max acceleration in mm/s^2 for retracts {SD Patch}

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -387,6 +387,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 // default settings
 
 #define DEFAULT_AXIS_STEPS_PER_UNIT   {78.7402,78.7402,200.0*8/3,760*1.1}  // default steps per unit for Ultimaker
+#define AXIS_STEPS_NEGATIVE           {78.7402,100.7402,200.0*8/3,760*1.1} // Step values to be used when travelling in the negative direction. Useful for threadless ball screws. Comment out if not needed
 #define DEFAULT_MAX_FEEDRATE          {500, 500, 5, 25}    // (mm/sec)
 #define DEFAULT_MAX_ACCELERATION      {9000,9000,100,10000}    // X, Y, Z, E maximum start speed for accelerated moves. E default values are good for skeinforge 40+, for older versions raise them a lot.
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -62,6 +62,10 @@
 //=============================public variables ============================
 //===========================================================================
 
+#ifdef AXIS_STEPS_NEGATIVE
+float negative_axis_steps_per_unit[] = AXIS_STEPS_NEGATIVE;
+#endif
+
 unsigned long minsegmenttime;
 float max_feedrate[4]; // set the max speeds
 float axis_steps_per_unit[4];
@@ -553,6 +557,17 @@ void plan_buffer_line(const float &x, const float &y, const float &z, const floa
   target[Z_AXIS] = lround(z*axis_steps_per_unit[Z_AXIS]);     
   target[E_AXIS] = lround(e*axis_steps_per_unit[E_AXIS]);
 
+// if movement is asymmetric in any axis, trick the position so that the travel happens with the correct amount of steps
+#ifdef AXIS_STEPS_NEGATIVE
+  for (int ax=0; ax<=NUM_AXIS; ax++)
+  {
+    if (target[ax] < position[ax])
+    {
+      position[ax] -= lround((target[ax]-position[ax])*(negative_axis_steps_per_unit[ax]/axis_steps_per_unit[ax]-1));
+    }
+  }
+#endif
+  
   #ifdef PREVENT_DANGEROUS_EXTRUDE
   if(target[E_AXIS]!=position[E_AXIS])
   {


### PR DESCRIPTION
This patch allows for a different number of steps in positive and negative direction. Useful for threadless ball screws.
